### PR TITLE
(enhancement) solve the problem of progress bar doesn't display properly

### DIFF
--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineService.kt
@@ -59,7 +59,7 @@ class GithubActionsPipelineService(
 
         try {
             val newRuns = pipelineRunService.getNewRuns(pipeline, emitCb)
-            val inProgressRuns = pipelineRunService.getInProgressRuns(pipeline)
+            val inProgressRuns = pipelineRunService.getInProgressRuns(pipeline, emitCb)
             newRuns.addAll(inProgressRuns)
             val totalBuildNumbersToSync = newRuns.size
             logger.info(

--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineService.kt
@@ -58,7 +58,7 @@ class GithubActionsPipelineService(
         val progressCounter = AtomicInteger(0)
 
         try {
-            val newRuns = pipelineRunService.getNewRuns(pipeline)
+            val newRuns = pipelineRunService.getNewRuns(pipeline, emitCb)
             val inProgressRuns = pipelineRunService.getInProgressRuns(pipeline)
             newRuns.addAll(inProgressRuns)
             val totalBuildNumbersToSync = newRuns.size

--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineService.kt
@@ -73,15 +73,6 @@ class GithubActionsPipelineService(
                 val convertedBuild = executionConverter.convertToBuild(it, pipeline.id, commits)
                 buildRepository.save(convertedBuild)
 
-                emitCb(
-                    SyncProgress(
-                        pipeline.id,
-                        pipeline.name,
-                        progressCounter.incrementAndGet(),
-                        totalBuildNumbersToSync
-                    )
-                )
-
                 logger.info("[${pipeline.id}] sync progress: [${progressCounter.get()}/$totalBuildNumbersToSync]")
                 convertedBuild
             }

--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineService.kt
@@ -66,7 +66,7 @@ class GithubActionsPipelineService(
                 "For Github Actions pipeline [${pipeline.id}] - " + "[$totalBuildNumbersToSync] need to be synced"
             )
 
-            val branchRunCommitsMap = pipelineCommitService.mapCommitToRun(pipeline, newRuns)
+            val branchRunCommitsMap = pipelineCommitService.mapCommitToRun(pipeline, newRuns, emitCb)
 
             val builds = newRuns.map {
                 val commits: List<Commit> = branchRunCommitsMap[it.branch]!![it]!!

--- a/backend/src/main/kotlin/metrik/project/domain/service/githubactions/PipelineRunService.kt
+++ b/backend/src/main/kotlin/metrik/project/domain/service/githubactions/PipelineRunService.kt
@@ -2,6 +2,7 @@ package metrik.project.domain.service.githubactions
 
 import metrik.project.domain.model.PipelineConfiguration
 import metrik.project.domain.repository.BuildRepository
+import metrik.project.rest.vo.response.SyncProgress
 import org.springframework.stereotype.Service
 import kotlin.streams.toList
 
@@ -11,9 +12,9 @@ class PipelineRunService(
     private val runService:RunService,
     private val branchService: BranchService
 ) {
-    fun getNewRuns(pipeline:PipelineConfiguration): MutableList<GithubActionsRun> {
+    fun getNewRuns(pipeline:PipelineConfiguration, emitCb: (SyncProgress) -> Unit): MutableList<GithubActionsRun> {
         val latestTimestamp = getLatestBuildTimeStamp(pipeline)
-        var newRuns = runService.syncRunsByPage(pipeline, latestTimestamp)
+        val newRuns = runService.syncRunsByPage(pipeline, latestTimestamp, emitCb)
         val branches = branchService.retrieveBranches(pipeline)
         return newRuns.filter { branches.contains(it.branch) } as MutableList<GithubActionsRun>
     }

--- a/backend/src/main/kotlin/metrik/project/infrastructure/github/feign/response/MultipleRunResponse.kt
+++ b/backend/src/main/kotlin/metrik/project/infrastructure/github/feign/response/MultipleRunResponse.kt
@@ -5,5 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 @JsonNaming(SnakeCaseStrategy::class)
 data class MultipleRunResponse(
-    val workflowRuns: List<SingleRunResponse>
+    val workflowRuns: List<SingleRunResponse>,
+    val totalCount: Int
 )

--- a/backend/src/main/kotlin/metrik/project/rest/vo/response/SyncProgress.kt
+++ b/backend/src/main/kotlin/metrik/project/rest/vo/response/SyncProgress.kt
@@ -4,7 +4,9 @@ data class SyncProgress(
     val pipelineId: String,
     val pipelineName: String,
     val progress: Int,
-    val batchSize: Int
+    val batchSize: Int,
+    val step: Int? = null,
+    val stepSize: Int? = null
 ) {
     override fun toString(): String {
         return "Pipeline [$pipelineId - $pipelineName]: $progress/$batchSize"

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/BranchServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/BranchServiceTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MockKExtension::class)
-internal class BranchesServiceTest {
+internal class BranchServiceTest {
     @InjectMockKs
     private lateinit var branchService: BranchService
 

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/CommitServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/CommitServiceTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.time.ZonedDateTime
 
 @ExtendWith(MockKExtension::class)
-internal class GithubCommitServiceTest {
+internal class CommitServiceTest {
 
     @InjectMockKs
     private lateinit var commitService: CommitService

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/ExecutionConverterTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/ExecutionConverterTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.time.ZonedDateTime
 
 @ExtendWith(MockKExtension::class)
-internal class GithubBuildConverterTest {
+internal class ExecutionConverterTest {
 
     @InjectMockKs
     private lateinit var executionConverter: ExecutionConverter

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/GithubActionsPipelineServiceTest.kt
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS", "LargeClass")
 @ExtendWith(MockKExtension::class)
-internal class GithubPipelineServiceTest {
+internal class GithubActionsPipelineServiceTest {
     @MockK(relaxed = true)
     private lateinit var buildRepository: BuildRepository
 

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/GithubPipelineServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/GithubPipelineServiceTest.kt
@@ -107,7 +107,7 @@ internal class GithubPipelineServiceTest {
 
     @Test
     fun `should sync and save all in-progress and completed-status builds to databases`() {
-        every { pipelineRunService.getNewRuns(githubActionsPipeline) } returns(mutableListOf( githubActionsRun1, githubActionsRun2))
+        every { pipelineRunService.getNewRuns(githubActionsPipeline, mockEmitCb ) } returns(mutableListOf( githubActionsRun1, githubActionsRun2))
         every { pipelineRunService.getInProgressRuns(githubActionsPipeline) } returns(listOf(githubActionsRun1, githubActionsRun2))
         every { pipelineCommitService.mapCommitToRun(githubActionsPipeline,any()) } returns mapOf(
             "master" to mapOf(githubActionsRun1 to listOf(commit)),

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/GithubPipelineServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/GithubPipelineServiceTest.kt
@@ -109,7 +109,7 @@ internal class GithubPipelineServiceTest {
     fun `should sync and save all in-progress and completed-status builds to databases`() {
         every { pipelineRunService.getNewRuns(githubActionsPipeline, mockEmitCb ) } returns(mutableListOf( githubActionsRun1, githubActionsRun2))
         every { pipelineRunService.getInProgressRuns(githubActionsPipeline, mockEmitCb) } returns(listOf(githubActionsRun1, githubActionsRun2))
-        every { pipelineCommitService.mapCommitToRun(githubActionsPipeline,any()) } returns mapOf(
+        every { pipelineCommitService.mapCommitToRun(githubActionsPipeline,any(), mockEmitCb) } returns mapOf(
             "master" to mapOf(githubActionsRun1 to listOf(commit)),
             "feature/CI pipeline" to mapOf(githubActionsRun2 to listOf(commit)
         ))

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/GithubPipelineServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/GithubPipelineServiceTest.kt
@@ -108,7 +108,7 @@ internal class GithubPipelineServiceTest {
     @Test
     fun `should sync and save all in-progress and completed-status builds to databases`() {
         every { pipelineRunService.getNewRuns(githubActionsPipeline, mockEmitCb ) } returns(mutableListOf( githubActionsRun1, githubActionsRun2))
-        every { pipelineRunService.getInProgressRuns(githubActionsPipeline) } returns(listOf(githubActionsRun1, githubActionsRun2))
+        every { pipelineRunService.getInProgressRuns(githubActionsPipeline, mockEmitCb) } returns(listOf(githubActionsRun1, githubActionsRun2))
         every { pipelineCommitService.mapCommitToRun(githubActionsPipeline,any()) } returns mapOf(
             "master" to mapOf(githubActionsRun1 to listOf(commit)),
             "feature/CI pipeline" to mapOf(githubActionsRun2 to listOf(commit)

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/PipelineCommitServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/PipelineCommitServiceTest.kt
@@ -1,4 +1,4 @@
-package metrik.project.domain.service.githubactions;
+package metrik.project.domain.service.githubactions
 
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -15,192 +15,197 @@ import java.time.ZonedDateTime
 
 @ExtendWith(MockKExtension::class)
 class PipelineCommitServiceTest {
-  @MockK(relaxed = true)
-  private lateinit var buildRepository: BuildRepository
+    @MockK(relaxed = true)
+    private lateinit var buildRepository: BuildRepository
 
-  @MockK(relaxed = true)
-  private lateinit var commitService: CommitService
+    @MockK(relaxed = true)
+    private lateinit var commitService: CommitService
 
-  @InjectMockKs
-  private lateinit var pipelineCommitService: PipelineCommitService
+    @InjectMockKs
+    private lateinit var pipelineCommitService: PipelineCommitService
 
- @Test
- fun `should map one run to its commits`() {
-  val build = githubActionsExecution.copy(changeSets = listOf(commit.copy(timestamp = previousTimeStamp)))
+    @Test
+    fun `should map one run to its commits`() {
+        val build = githubActionsExecution.copy(changeSets = listOf(commit.copy(timestamp = previousTimeStamp)))
 
-  every {
-   buildRepository.getPreviousBuild(
-    pipelineId,
-    currentTimeStamp,
-    branch
-   )
-  } returns build
+        every {
+            buildRepository.getPreviousBuild(
+                pipelineId,
+                currentTimeStamp,
+                branch
+            )
+        } returns build
 
-  every {
-   commitService.getCommitsBetweenTimePeriod(
-    ZonedDateTime.parse("2021-04-23T13:41:01.779Z")!!.toTimestamp(),
-    ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
-    branch = branch,
-    pipeline = githubActionsPipeline
-   )
-  } returns listOf(commit)
+        every {
+            commitService.getCommitsBetweenTimePeriod(
+                ZonedDateTime.parse("2021-04-23T13:41:01.779Z")!!.toTimestamp(),
+                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                branch = branch,
+                pipeline = githubActionsPipeline
+            )
+        } returns listOf(commit)
 
-  val map = mapOf(branch to mapOf(githubActionsRun1 to listOf(commit)))
+        val map = mapOf(branch to mapOf(githubActionsRun1 to listOf(commit)))
 
-  val actualMap = pipelineCommitService.mapCommitToRun(
-   githubActionsPipeline,
-   mutableListOf(githubActionsRun1)
-  )
-  Assertions.assertEquals(map, actualMap)
- }
+        val actualMap = pipelineCommitService.mapCommitToRun(
+            githubActionsPipeline,
+            mutableListOf(githubActionsRun1),
+            mockEmitCb
+        )
+        Assertions.assertEquals(map, actualMap)
+    }
 
 
- @Test
- fun `should map one run to its commit given no previous build and commits are in correct time range`() {
-  every {
-   buildRepository.getPreviousBuild(
-    pipelineId,
-    currentTimeStamp,
-    branch
-   )
-  } returns null
+    @Test
+    fun `should map one run to its commit given no previous build and commits are in correct time range`() {
+        every {
+            buildRepository.getPreviousBuild(
+                pipelineId,
+                currentTimeStamp,
+                branch
+            )
+        } returns null
 
-  every {
-   commitService.getCommitsBetweenTimePeriod(
-    startTimeStamp = 0,
-    ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
-    branch = branch,
-    pipeline = githubActionsPipeline
-   )
-  } returns listOf(commit)
+        every {
+            commitService.getCommitsBetweenTimePeriod(
+                startTimeStamp = 0,
+                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                branch = branch,
+                pipeline = githubActionsPipeline
+            )
+        } returns listOf(commit)
 
-  val map = mapOf(branch to mapOf(githubActionsRun1 to listOf(commit)))
+        val map = mapOf(branch to mapOf(githubActionsRun1 to listOf(commit)))
 
-  Assertions.assertEquals(
-   map,
-   pipelineCommitService.mapCommitToRun(
-    githubActionsPipeline,
-    mutableListOf(githubActionsRun1)
-   )
-  )
- }
+        Assertions.assertEquals(
+            map,
+            pipelineCommitService.mapCommitToRun(
+                githubActionsPipeline,
+                mutableListOf(githubActionsRun1),
+                mockEmitCb
+            )
+        )
+    }
 
- @Test
- fun `should map one run to its commit given no previous build and commits are not in correct time range`() {
-  every {
-   buildRepository.getPreviousBuild(
-    pipelineId,
-    currentTimeStamp,
-    branch
-   )
-  } returns null
+    @Test
+    fun `should map one run to its commit given no previous build and commits are not in correct time range`() {
+        every {
+            buildRepository.getPreviousBuild(
+                pipelineId,
+                currentTimeStamp,
+                branch
+            )
+        } returns null
 
-  every {
-   commitService.getCommitsBetweenTimePeriod(
-    0,
-    ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
-    branch = branch,
-    pipeline = githubActionsPipeline
-   )
-  } returns listOf(commit.copy(timestamp = 1629856700010))
+        every {
+            commitService.getCommitsBetweenTimePeriod(
+                0,
+                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                branch = branch,
+                pipeline = githubActionsPipeline
+            )
+        } returns listOf(commit.copy(timestamp = 1629856700010))
 
-  val map = mapOf(branch to mapOf(githubActionsRun1 to emptyList<Commit>()))
+        val map = mapOf(branch to mapOf(githubActionsRun1 to emptyList<Commit>()))
 
-  Assertions.assertEquals(
-   map,
-   pipelineCommitService.mapCommitToRun(
-    githubActionsPipeline,
-    mutableListOf(githubActionsRun1)
-   )
-  )
- }
+        Assertions.assertEquals(
+            map,
+            pipelineCommitService.mapCommitToRun(
+                githubActionsPipeline,
+                mutableListOf(githubActionsRun1),
+                mockEmitCb
+            )
+        )
+    }
 
- @Test
- fun `should map multiple runs to their commits`() {
-  val buildFirst = githubActionsExecution.copy(changeSets = listOf(commit.copy(timestamp = previousTimeStamp)))
-  val buildSecond = githubActionsExecution.copy(changeSets = listOf(commit.copy(timestamp = 1619098860779)))
-  val buildThird = githubActionsExecution.copy(changeSets = listOf(commit.copy(timestamp = 1618926060779)))
+    @Test
+    fun `should map multiple runs to their commits`() {
+        val buildFirst = githubActionsExecution.copy(changeSets = listOf(commit.copy(timestamp = previousTimeStamp)))
+        val buildSecond = githubActionsExecution.copy(changeSets = listOf(commit.copy(timestamp = 1619098860779)))
+        val buildThird = githubActionsExecution.copy(changeSets = listOf(commit.copy(timestamp = 1618926060779)))
 
-  val githubActionsRun2 = githubActionsRun1.copy(
-   commitTimeStamp = ZonedDateTime.parse("2021-04-23T13:41:00.779Z")
-  )
+        val githubActionsRun2 = githubActionsRun1.copy(
+            commitTimeStamp = ZonedDateTime.parse("2021-04-23T13:41:00.779Z")
+        )
 
-  val githubActionsRun3 = githubActionsRun1.copy(
-   commitTimeStamp = ZonedDateTime.parse("2021-04-22T13:41:00.779Z")
-  )
+        val githubActionsRun3 = githubActionsRun1.copy(
+            commitTimeStamp = ZonedDateTime.parse("2021-04-22T13:41:00.779Z")
+        )
 
-  every {
-   buildRepository.getPreviousBuild(
-    pipelineId,
-    any(),
-    branch
-   )
-  } returns buildThird andThen buildFirst andThen buildSecond andThen buildThird
+        every {
+            buildRepository.getPreviousBuild(
+                pipelineId,
+                any(),
+                branch
+            )
+        } returns buildThird andThen buildFirst andThen buildSecond andThen buildThird
 
-  val commit1 = commit.copy(timestamp = 1629203005000)
-  val commit2 = commit.copy(timestamp = 1619185260779)
-  val commit3 = commit.copy(timestamp = 1619098860779)
+        val commit1 = commit.copy(timestamp = 1629203005000)
+        val commit2 = commit.copy(timestamp = 1619185260779)
+        val commit3 = commit.copy(timestamp = 1619098860779)
 
-  every {
-   commitService.getCommitsBetweenTimePeriod(
-    ZonedDateTime.parse("2021-04-20T13:41:01.779Z")!!.toTimestamp(),
-    ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
-    branch = branch,
-    pipeline = githubActionsPipeline
-   )
-  } returns listOf(commit1, commit2, commit3)
+        every {
+            commitService.getCommitsBetweenTimePeriod(
+                ZonedDateTime.parse("2021-04-20T13:41:01.779Z")!!.toTimestamp(),
+                ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                branch = branch,
+                pipeline = githubActionsPipeline
+            )
+        } returns listOf(commit1, commit2, commit3)
 
-  val map = mapOf(
-   branch to mapOf(
-    githubActionsRun1 to listOf(commit1),
-    githubActionsRun2 to listOf(commit2),
-    githubActionsRun3 to listOf(commit3)
-   )
-  )
-  val runs = mutableListOf(githubActionsRun1, githubActionsRun2, githubActionsRun3)
-  println(runs);
-  Assertions.assertEquals(
-   map,
-   pipelineCommitService.mapCommitToRun(
-    githubActionsPipeline,
-    runs
-   )
-  )
- }
+        val map = mapOf(
+            branch to mapOf(
+                githubActionsRun1 to listOf(commit1),
+                githubActionsRun2 to listOf(commit2),
+                githubActionsRun3 to listOf(commit3)
+            )
+        )
+        val runs = mutableListOf(githubActionsRun1, githubActionsRun2, githubActionsRun3)
 
- @Test
- fun `should map first run given previous run does not have commits`() {
-  val build = githubActionsExecution.copy(changeSets = emptyList())
+        Assertions.assertEquals(
+            map,
+            pipelineCommitService.mapCommitToRun(
+                githubActionsPipeline,
+                runs,
+                mockEmitCb
+            )
+        )
+    }
 
-  every {
-   buildRepository.getPreviousBuild(
-    pipelineId,
-    any(),
-    branch
-   )
-  } returns build
+    @Test
+    fun `should map first run given previous run does not have commits`() {
+        val build = githubActionsExecution.copy(changeSets = emptyList())
 
-  every {
-   commitService.getCommitsBetweenTimePeriod(
-    startTimeStamp = 0,
-    endTimeStamp = ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
-    branch = branch,
-    pipeline = githubActionsPipeline
-   )
-  } returns listOf(commit)
+        every {
+            buildRepository.getPreviousBuild(
+                pipelineId,
+                any(),
+                branch
+            )
+        } returns build
 
-  val map = mapOf(
-   branch to mapOf(
-    githubActionsRun1 to listOf(commit),
-   )
-  )
+        every {
+            commitService.getCommitsBetweenTimePeriod(
+                startTimeStamp = 0,
+                endTimeStamp = ZonedDateTime.parse("2021-08-17T12:23:25Z")!!.toTimestamp(),
+                branch = branch,
+                pipeline = githubActionsPipeline
+            )
+        } returns listOf(commit)
 
-  Assertions.assertEquals(
-   map,
-   pipelineCommitService.mapCommitToRun(
-    githubActionsPipeline,
-    mutableListOf(githubActionsRun1)
-   )
-  )
- }
+        val map = mapOf(
+            branch to mapOf(
+                githubActionsRun1 to listOf(commit),
+            )
+        )
+
+        Assertions.assertEquals(
+            map,
+            pipelineCommitService.mapCommitToRun(
+                githubActionsPipeline,
+                mutableListOf(githubActionsRun1),
+                mockEmitCb
+            )
+        )
+    }
 }

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/PipelineRunServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/PipelineRunServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.verify
 import metrik.project.*
 import metrik.project.domain.model.Status
 import metrik.project.domain.repository.BuildRepository
@@ -44,6 +45,7 @@ internal class PipelineRunServiceTest {
 
         Assertions.assertThat(validNewRuns.size).isEqualTo(1)
         Assertions.assertThat(validNewRuns[0]).isEqualTo(githubActionsRun1)
+        verify(exactly = 1) { mockEmitCb(any()) }
     }
 
     @Test
@@ -52,9 +54,10 @@ internal class PipelineRunServiceTest {
         every { buildRepository.getInProgressBuilds(pipelineId) } returns(listOf(build))
         every { runService.syncSingleRun(any(), any()) } returns(githubActionsRun2)
 
-        val inProgressRuns = pipelineRunService.getInProgressRuns(githubActionsPipeline)
+        val inProgressRuns = pipelineRunService.getInProgressRuns(githubActionsPipeline, mockEmitCb)
 
         Assertions.assertThat(inProgressRuns.size).isEqualTo(1)
         Assertions.assertThat(inProgressRuns).isEqualTo(listOf(githubActionsRun2))
+        verify(exactly = 1) { mockEmitCb(any()) }
     }
 }

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/PipelineRunServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/PipelineRunServiceTest.kt
@@ -40,7 +40,7 @@ internal class PipelineRunServiceTest {
             "master",
             "feature/CD pipeline"
         )
-        val validNewRuns = pipelineRunService.getNewRuns(githubActionsPipeline)
+        val validNewRuns = pipelineRunService.getNewRuns(githubActionsPipeline, mockEmitCb)
 
         Assertions.assertThat(validNewRuns.size).isEqualTo(1)
         Assertions.assertThat(validNewRuns[0]).isEqualTo(githubActionsRun1)

--- a/backend/src/test/kotlin/metrik/project/domain/service/githubactions/RunServiceTest.kt
+++ b/backend/src/test/kotlin/metrik/project/domain/service/githubactions/RunServiceTest.kt
@@ -10,6 +10,7 @@ import metrik.project.domain.model.PipelineConfiguration
 import metrik.project.infrastructure.github.feign.GithubFeignClient
 import metrik.project.infrastructure.github.feign.response.MultipleRunResponse
 import metrik.project.infrastructure.github.feign.response.SingleRunResponse
+import metrik.project.mockEmitCb
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -33,23 +34,27 @@ internal class RunServiceTest {
             listOf(
                 SingleRunResponse(createdAt = ZonedDateTime.of(2021, 1, 10, 0, 0, 0, 0, ZoneId.systemDefault())),
                 SingleRunResponse(createdAt = ZonedDateTime.of(2021, 1, 9, 0, 0, 0, 0, ZoneId.systemDefault())),
-            )
+            ),
+            2
         )
         every { githubFeignClient.retrieveMultipleRuns(any(), any(), any(), 2, 2) } returns MultipleRunResponse(
             listOf(
                 SingleRunResponse(createdAt = ZonedDateTime.of(2021, 1, 8, 0, 0, 0, 0, ZoneId.systemDefault())),
                 SingleRunResponse(createdAt = ZonedDateTime.of(2021, 1, 7, 0, 0, 0, 0, ZoneId.systemDefault())),
-            )
+            ),
+            2
         )
         every { githubFeignClient.retrieveMultipleRuns(any(), any(), any(), 2, 3) } returns MultipleRunResponse(
             listOf(
                 SingleRunResponse(createdAt = ZonedDateTime.of(2021, 1, 6, 0, 0, 0, 0, ZoneId.systemDefault())),
-            )
+            ),
+            1
         )
 
         val syncedRuns = runService.syncRunsByPage(
             testPipeline,
             ZonedDateTime.of(2021, 1, 7, 0, 0, 0, 0, ZoneId.systemDefault()).toTimestamp(),
+            mockEmitCb,
             2
         )
 

--- a/frontend/scripts/webpack.dev.js
+++ b/frontend/scripts/webpack.dev.js
@@ -16,6 +16,7 @@ const devConfig = {
 		},
 		open: true,
 		historyApiFallback: true,
+		compress: false,
 		proxy: {
 			"/api": "http://localhost:9000",
 		},

--- a/frontend/src/globalStyle.ts
+++ b/frontend/src/globalStyle.ts
@@ -14,6 +14,9 @@ export const globalStyles = {
 	".fullscreen-dashboard-modal.ant-modal-wrap": {
 		overflow: "hidden",
 	},
+	".ant-progress-text": {
+		width: "auto",
+	},
 	"::-webkit-scrollbar": {
 		backgroundColor: "transparent",
 		width: "thin",

--- a/frontend/src/pages/dashboard/components/SyncProgressContent.tsx
+++ b/frontend/src/pages/dashboard/components/SyncProgressContent.tsx
@@ -17,6 +17,8 @@ export interface ProgressUpdateEvt {
 	pipelineName: string;
 	progress: number;
 	batchSize: number;
+	step?: number;
+	stepSize?: number;
 }
 
 export interface ProgressSummary {
@@ -49,7 +51,10 @@ export const SyncProgressContent: React.FC<SyncProgressContentProps> = ({ progre
 									100
 							)}
 							format={() =>
-								`${progressSummary[progressKey]?.progress}/${progressSummary[progressKey]?.batchSize}`
+								`${progressSummary[progressKey]?.progress}/${progressSummary[progressKey]?.batchSize}` +
+								(progressSummary[progressKey]?.stepSize
+									? `(Step ${progressSummary[progressKey]?.step}/${progressSummary[progressKey]?.stepSize})`
+									: "")
 							}
 						/>
 					</td>

--- a/frontend/src/pages/dashboard/components/SyncProgressContent.tsx
+++ b/frontend/src/pages/dashboard/components/SyncProgressContent.tsx
@@ -36,30 +36,33 @@ export const SyncProgressContent: React.FC<SyncProgressContentProps> = ({ progre
 		<p>Waiting server response...</p>
 	) : (
 		<table>
-			{Object.keys(progressSummary).map(progressKey => (
-				<tr key={progressKey} css={tableRowStyles}>
-					<td>{progressSummary[progressKey]?.pipelineName}:</td>
-					<td>
-						<Progress
-							type="line"
-							strokeWidth={12}
-							size="small"
-							steps={50}
-							strokeColor="#D63F97"
-							percent={Math.floor(
-								(progressSummary[progressKey]?.progress / progressSummary[progressKey]?.batchSize) *
-									100
-							)}
-							format={() =>
-								`${progressSummary[progressKey]?.progress}/${progressSummary[progressKey]?.batchSize}` +
-								(progressSummary[progressKey]?.stepSize
-									? `(Step ${progressSummary[progressKey]?.step}/${progressSummary[progressKey]?.stepSize})`
-									: "")
-							}
-						/>
-					</td>
-				</tr>
-			))}
+			<tbody>
+				{Object.keys(progressSummary).map(progressKey => (
+					<tr key={progressKey} css={tableRowStyles}>
+						<td>{progressSummary[progressKey]?.pipelineName}:</td>
+						<td>
+							<Progress
+								type="line"
+								strokeWidth={12}
+								size="small"
+								steps={50}
+								strokeColor="#D63F97"
+								percent={Math.floor(
+									(progressSummary[progressKey]?.progress /
+										progressSummary[progressKey]?.batchSize) *
+										100
+								)}
+								format={() =>
+									`${progressSummary[progressKey]?.progress}/${progressSummary[progressKey]?.batchSize}` +
+									(progressSummary[progressKey]?.stepSize
+										? `(Step ${progressSummary[progressKey]?.step}/${progressSummary[progressKey]?.stepSize})`
+										: "")
+								}
+							/>
+						</td>
+					</tr>
+				))}
+			</tbody>
 		</table>
 	);
 };


### PR DESCRIPTION
https://github.com/thoughtworks/metrik/issues/95
Divide the fetching progress into 3 "steps" and show: fetching new runs, fetching in-progress runs and fetching commits. Remove redundant emitCb during mapping of runs and commits.
Fix the problem of SSE cached due to the webpack.
Fix the problem of tests' name and services' name don't match.